### PR TITLE
Fix Datenschutzerklärung 2: JS was missing and quotationmarks replaced

### DIFF
--- a/datenschutz2.html
+++ b/datenschutz2.html
@@ -71,7 +71,7 @@
 <body>
     <div class="container">
         <div class="notice">
-            Diese Datenschutzerklärung enthält versteckte problematische Stellen. Klicke auf Aussagen, die dir auffällig erscheinen, um sie zu prüfen und zu verbessern. Sobald alle Korrekturen vorgenommen wurden, erhältst du eine vollständige, präzise Datenschutzerklärung. Die vollständige Datenschutzerklärung kann unter <a href="datenschutzerklaerung.html">diesem Link</a> eingesehen werden.
+            Diese Datenschutzerklärung enthält versteckte problematische Stellen. Klicke auf Aussagen, die dir auffällig erscheinen, um sie zu prüfen und zu verbessern. Sobald alle Korrekturen vorgenommen wurden, erhältst du eine vollständige, präzise Datenschutzerklärung. Die vollständige Datenschutzerklärung kann unter <a href="datenschutz.html">diesem Link</a> eingesehen werden.
         </div>
 
         <h1>Datenschutzerklärung</h1>


### PR DESCRIPTION
JS was most likely accidentally removed in 7183ce87640a742005d2244fbbdaf934a0823a1b.

Before:
![grafik](https://github.com/user-attachments/assets/eb5b4c80-b0fb-41a9-9885-05734b3421ac)

After:
![grafik](https://github.com/user-attachments/assets/8a68867f-d73e-48a1-a7e5-a6dc537a9b46)
